### PR TITLE
Merge doc8-readme into doc8 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
     # docs stage
     - stage: docs
       env: TOXENV=doc8
-    - env: TOXENV=doc8-readme
     - env: TOXENV=readme
     - env: TOXENV=docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ envlist =
     xenon
     # documentation linters/checkers
     doc8
-    doc8-readme
     readme
     docs
     # the actual tests
@@ -103,16 +102,8 @@ deps =
     doc8
     pygments
 skip_install = true
-commands = doc8 docs/source/
-description = Run the doc8 tool to check the style of the RST files in the project docs.
-
-[testenv:doc8-readme]
-deps =
-    doc8
-    pygments
-skip_install = true
-commands = doc8 README.rst
-description = Run the doc8 tool to check the style of the README.rst file.
+commands =  doc8 docs/source/ README.rst
+description = Run the doc8 tool to check the style of the RST files in the project docs and the README.rst file.
 
 [testenv:readme]
 deps =


### PR DESCRIPTION
Closes #1 

- Merge doc8-readme into doc8 in tox.ini
- Remove doc8-readme from .travis.yml