### PR TITLE
Annoyingly short PR for updating code style in exceptions.py

### DIFF
--- a/src/flagman/exceptions.py
+++ b/src/flagman/exceptions.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
+
 """Exceptions for flagman."""
 
 
 class ActionClosed(Exception):
     """The Action is closed and no longer will do anything on a call to `run()`."""
-
-    pass


### PR DESCRIPTION
If there's a docstring, you don't need a pass